### PR TITLE
update adk run summary api to support template variables

### DIFF
--- a/packages/quokka-entities/run-summaries/lib/run-summaries.ts
+++ b/packages/quokka-entities/run-summaries/lib/run-summaries.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import { setOutput } from '@quokka/adk-core';
-import { RunSummaryLevel, RunSummary } from './types/types';
+import { RunSummaryLevel, RunSummary, TemplateVariable } from './types/types';
 
 const ACTION_RUN_SUMMARY: string = 'ACTION_RUN_SUMMARY';
 const MAX_RUN_SUMMARY_TEXT_LENGTH: number = 200;
@@ -8,10 +8,15 @@ const MAX_RUN_SUMMARY_TEXT_LENGTH: number = 200;
 export class RunSummaries {
     static runSummaries: RunSummary[] = [];
 
-    public static addRunSummary(text: string | Error, type: RunSummaryLevel): void {
+    /*
+    This api as of now is suboptimal. The 'text' parameter for now accepts both status code and error message to avoid
+    any breaking changes. We will be changing the api behaviour later.
+    */
+    public static addRunSummary(text: string | Error, type: RunSummaryLevel, templateVariables?: TemplateVariable[]): void {
         const runSummary: RunSummary = {
             text: JSON.stringify(this.truncate(text.toString(), MAX_RUN_SUMMARY_TEXT_LENGTH)),
             level: type,
+            templateVariables: templateVariables,
         };
         this.runSummaries.push(runSummary);
         setOutput(ACTION_RUN_SUMMARY, JSON.stringify(this.runSummaries));

--- a/packages/quokka-entities/run-summaries/lib/types/types.ts
+++ b/packages/quokka-entities/run-summaries/lib/types/types.ts
@@ -3,7 +3,7 @@
  * Currently, we only support error messages being surfaced.
  */
 export enum RunSummaryLevel {
-    ERROR = "Error"
+    ERROR = 'Error'
 }
 
 /**
@@ -13,4 +13,10 @@ export enum RunSummaryLevel {
 export interface RunSummary {
     text: string,
     level: RunSummaryLevel,
+    templateVariables?: TemplateVariable[]
+}
+
+export interface TemplateVariable {
+    name: string,
+    value: string
 }

--- a/packages/quokka-entities/run-summaries/test/run-summaries.test.ts
+++ b/packages/quokka-entities/run-summaries/test/run-summaries.test.ts
@@ -5,6 +5,7 @@ import {
     RunSummaryLevel, 
     RunSummaries,
 } from '../lib';
+import { TemplateVariable } from '../lib/types/types';
 
 jest.mock('@quokka/adk-core/lib/toolkit/sdk/core/command-wrapper');
 const ACTION_RUN_SUMMARY: string = 'ACTION_RUN_SUMMARY';
@@ -133,6 +134,27 @@ describe('runSummaries', () => {
 
         RunSummaries.addRunSummary(longText, RunSummaryLevel.ERROR);
         
+        expect(core.setOutput).toHaveBeenCalledWith(ACTION_RUN_SUMMARY, JSON.stringify(expectedRunSummaries));
+    });
+
+    it('addRunSummary sets the expected output variable to an array with 1 run summary with string type text and template variables', () => {
+        const runSummaryText: string = 'Single runSummary';
+        const expectedTemplateVariables: TemplateVariable[] = [
+            {
+                name: 'parameter1',
+                value: 'value1',
+            },
+        ];
+        const expectedRunSummaries: RunSummary[] = [
+            {
+                text: JSON.stringify(runSummaryText),
+                level: RunSummaryLevel.ERROR,
+                templateVariables: expectedTemplateVariables,
+            },
+        ];
+
+        RunSummaries.addRunSummary(runSummaryText, RunSummaryLevel.ERROR, expectedTemplateVariables);
+
         expect(core.setOutput).toHaveBeenCalledWith(ACTION_RUN_SUMMARY, JSON.stringify(expectedRunSummaries));
     });
 });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated adk run summary api to support parameterized error handling through 1p actions. We allow template variables to be passed from actions which is a list of name value pairs. These template variables will be substituted in the actual error message on the workflows ui

Example Summary Message Structure:

```
{
  text: Stack name {{STACK_NAME}} can only contain letters, numbers, spaces, underscores, periods and forward slashes.
  level: ERROR
  templateVariables: [
      {
        name: STACK_NAME
        value: InvalidStack
      }
  ]
}
```

The error message on the ui will look like

```
Stack name InvalidStack can only contain letters, numbers, spaces, underscores, periods and forward slashes.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
