### PR TITLE
sanitize user input to prevent code injection

### DIFF
--- a/packages/adk-model-parser/lib/index.ts
+++ b/packages/adk-model-parser/lib/index.ts
@@ -1,3 +1,3 @@
-export { parseModelFile } from './parser/parser';
+export { sanitizeAndParseModelFile } from './parser/parser';
 export { generateModelFile } from './generator/generator';
 export { Model, Configuration, Input, RunConfig } from './types/types';

--- a/packages/adk-model-parser/lib/parser/parser.ts
+++ b/packages/adk-model-parser/lib/parser/parser.ts
@@ -1,11 +1,12 @@
-import chalk from 'chalk';
 import fs from 'fs';
 import yaml from 'js-yaml';
 import { Model } from '../types/types';
+import { sanitizeFile } from '../sanitizer/sanitizer';
 
-export function parseModelFile(fileName: any): Model {
-    console.log(chalk.green('Starting parsing file ' + fileName));
-    return parseModelFileContents(fs.readFileSync(fileName, 'utf8'));
+export function sanitizeAndParseModelFile(fileName: any): Model {
+    let modelFile = fs.readFileSync(fileName, 'utf8');
+    let sanitizedModelFile = sanitizeFile(modelFile);
+    return parseModelFileContents(sanitizedModelFile);
 }
 
 function parseModelFileContents(fileContents: any): Model {

--- a/packages/adk-model-parser/lib/sanitizer/sanitizer.ts
+++ b/packages/adk-model-parser/lib/sanitizer/sanitizer.ts
@@ -1,0 +1,21 @@
+const defaultSkipPrefixes = ['- run', '- Run'];
+
+export function sanitizeFile(file: string): string {
+    let sanitizedModelFile = '';
+    file.split(/\r?\n/).forEach(line => {
+        let skipLine = defaultSkipPrefixes?.some(prefix => {
+            return (line.trim().startsWith(prefix));
+        });
+        sanitizedModelFile += skipLine ? line : sanitizeLine(line);
+    });
+    return sanitizedModelFile;
+};
+
+function sanitizeLine(text: string): string {
+    return text
+        .replace(/;/g, '')
+        .replace(/&/g, '')
+        .replace(/$/g, '')
+        .replace(/\\n/g, '')
+        .replace(/\\r/g, '') + '\n';
+};

--- a/packages/adk-model-parser/test/action.yml
+++ b/packages/adk-model-parser/test/action.yml
@@ -11,3 +11,7 @@ outputs:
 runs:
   using: 'node12'
   main: 'index.js'
+jobs:
+  job1:
+    steps:
+      - run: ls; pwd;

--- a/packages/adk-model-parser/test/index.test.ts
+++ b/packages/adk-model-parser/test/index.test.ts
@@ -5,7 +5,7 @@ import { Model } from '../lib/types/types';
 
 describe('@quokka/adk-model-parser parse file', () => {
     it('parse model file contents', async () => {
-        parser.parseModelFile(`${__dirname}/action.yml`);
+        parser.sanitizeAndParseModelFile(`${__dirname}/action.yml`);
     });
 });
 

--- a/packages/adk-model-parser/test/sanitizer.test.ts
+++ b/packages/adk-model-parser/test/sanitizer.test.ts
@@ -1,0 +1,19 @@
+'use strict';
+
+import { sanitizeFile } from '../lib/sanitizer/sanitizer';
+import fs from 'fs';
+
+jest.mock('fs', () => ({
+    ...jest.requireActual('fs'),
+    writeFileSync: jest.fn(),
+    mkdirSync: jest.fn(),
+    copyFileSync: jest.fn(),
+}));
+
+describe('Action.yaml Sanitizer Test', () => {
+    const fileName = `${__dirname}/action.yml`;
+    it('ensure line with \"- run\" is not sanitized', async () => {
+        let sanitizedFile = sanitizeFile(fs.readFileSync(fileName, 'utf8'));
+        expect(sanitizedFile.includes('- run: ls; pwd;')).toBeTruthy();
+    });
+});

--- a/packages/adk/lib/bootstrap/controller.ts
+++ b/packages/adk/lib/bootstrap/controller.ts
@@ -1,29 +1,30 @@
 import { Controller, Logger } from '@nestjs/common';
 import { ActionPreValidationRules } from './rule';
 import { GeneratorProps } from './model';
-import { Model, parseModelFile} from '@quokka/adk-model-parser';
+import { sanitizeAndParseModelFile } from '@quokka/adk-model-parser';
 import { ActionBootstrapGenerators } from './generators';
 
 @Controller()
 export class BootstrapController {
-    constructor(private preValidationRules: ActionPreValidationRules,
-                private boootstrapGenerator: ActionBootstrapGenerators) {
+    constructor(
+        private preValidationRules: ActionPreValidationRules,
+        private boootstrapGenerator: ActionBootstrapGenerators) {
     }
 
     bootstrapAction(props: GeneratorProps) {
         if (!this.preValidationRules.apply(props)) {
-            Logger.error('Bootstrap pre-validation Failed, still continuing');
-            //return 1;
+            Logger.error('Bootstrap pre-validation Failed');
+            // return 1;
         }
 
         // validation complete, now apply generators
         Logger.log('Validation succeeded for bootstrap');
         console.log(`Properties file: ${props.file}`);
-        if (this.boootstrapGenerator.bootstrap(parseModelFile(props.file), props)) {
-          return 0;
+        if (this.boootstrapGenerator.bootstrap(sanitizeAndParseModelFile(props.file), props)) {
+            return 0;
         } else {
-          Logger.error('Bootstrapping Failed');
-          return 1;
+            Logger.error('Bootstrapping Failed');
+            return 1;
         }
     }
 }

--- a/packages/adk/lib/bootstrap/generators.ts
+++ b/packages/adk/lib/bootstrap/generators.ts
@@ -8,18 +8,18 @@ import { GeneratorProps } from './model';
 @Injectable({ scope: Scope.DEFAULT })
 export class ActionBootstrapGenerators {
 
-  constructor(@Inject(TEMPLATE_GENERATOR) private templateGenerator: TemplateGenerator) {
+    constructor(@Inject(TEMPLATE_GENERATOR) private templateGenerator: TemplateGenerator) {
 
-  }
-
-  bootstrap(actionModel: Model, props: GeneratorProps) {
-    const templateGenResult = this.templateGenerator.generate(actionModel, props);
-
-    if (!templateGenResult.pass()) {
-        Logger.error(`Unable to generate bootstrap code: ${templateGenResult.errors()}`);
-        return false;
-    } else {
-        return true;
     }
-  }
+
+    bootstrap(actionModel: Model, props: GeneratorProps) {
+        const templateGenResult = this.templateGenerator.generate(actionModel, props);
+
+        if (!templateGenResult.pass()) {
+            Logger.error(`Unable to generate bootstrap code: ${templateGenResult.errors()}`);
+            return false;
+        } else {
+            return true;
+        }
+    }
 }

--- a/packages/adk/lib/bootstrap/generators/code.ts
+++ b/packages/adk/lib/bootstrap/generators/code.ts
@@ -1,28 +1,27 @@
 import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
-import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError } from '../model';
+import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
 import { PACKAGE_JSON_GENERATOR, PackageJsonGenerator } from './packagejson';
 import { RUNTIME_CODE_GENERATOR, RuntimeCodeGenerator } from './runtime';
 import { Model } from '@quokka/adk-model-parser';
-import { GeneratorProps } from '../model';
 
 export const CODE_GENERATOR = 'code_generator';
 
 @Injectable({ scope: Scope.DEFAULT })
 export class BootstrapCodeGenerator implements BoootstrapGenerator {
 
-  constructor(@Inject(PACKAGE_JSON_GENERATOR) private packageJsonGen: PackageJsonGenerator,
-              @Inject(RUNTIME_CODE_GENERATOR) private runtimeCodeGen: RuntimeCodeGenerator) {
+    constructor(
+        @Inject(PACKAGE_JSON_GENERATOR) private packageJsonGen: PackageJsonGenerator,
+        @Inject(RUNTIME_CODE_GENERATOR) private runtimeCodeGen: RuntimeCodeGenerator) {
+    }
 
-  }
-
-  generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
-      try {
-          this.packageJsonGen.generate(model, props);
-          this.runtimeCodeGen.generate(model, props);
-          return new BootstrapGeneratorResult();
-      } catch (e) {
-          Logger.error(e);
-          throw new BootstrapError(`${e}`);
-      }
-  }
+    generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
+        try {
+            this.packageJsonGen.generate(model, props);
+            this.runtimeCodeGen.generate(model, props);
+            return new BootstrapGeneratorResult();
+        } catch (e) {
+            Logger.error(e);
+            throw new BootstrapError(`${e}`);
+        }
+    }
 }

--- a/packages/adk/lib/bootstrap/generators/fscopy.ts
+++ b/packages/adk/lib/bootstrap/generators/fscopy.ts
@@ -1,31 +1,30 @@
 import fs from 'fs';
 import { applyTemplate } from '../../util/template';
 import { Injectable, Logger, Scope } from '@nestjs/common';
-import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError } from '../model';
+import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
 import { Model } from '@quokka/adk-model-parser';
-import { GeneratorProps } from '../model';
 
 export const FILE_COPY_GENERATOR = 'file_copy_generator';
 
 @Injectable({ scope: Scope.DEFAULT })
 export class FileCopyGenerator implements BoootstrapGenerator {
 
-  generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
-      try {
-          Logger.log('Copying files from template..');
-          const files = ['tsconfig.json', '.prettierrc.json'];
-          files.forEach ( (fl) => {
-            // fs.copyFileSync(`${__dirname}/../../../templates/action/typescript/${fl}`, `${fl}`, fs.constants.COPYFILE_EXCL);
-            fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/${fl}`, `${fl}`, fs.constants.COPYFILE_EXCL);
-          });
+    generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
+        try {
+            Logger.log('Copying files from template..');
+            const files = ['tsconfig.json', '.prettierrc.json'];
+            files.forEach((fl) => {
+                // fs.copyFileSync(`${__dirname}/../../../templates/action/typescript/${fl}`, `${fl}`, fs.constants.COPYFILE_EXCL);
+                fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/${fl}`, `${fl}`, fs.constants.COPYFILE_EXCL);
+            });
 
-          fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/gitignore`, '.gitignore', fs.constants.COPYFILE_EXCL);
-          fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/eslintrc`, '.eslintrc.js', fs.constants.COPYFILE_EXCL);
-          fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/jest.conf`, 'jest.config.js', fs.constants.COPYFILE_EXCL);
-          return new BootstrapGeneratorResult();
-      } catch (e) {
-          Logger.error(e);
-          throw new BootstrapError(`${e}`);
-      }
-  }
+            fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/gitignore`, '.gitignore', fs.constants.COPYFILE_EXCL);
+            fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/eslintrc`, '.eslintrc.js', fs.constants.COPYFILE_EXCL);
+            fs.copyFileSync(`${props.templateBasePath}/templates/action/typescript/jest.conf`, 'jest.config.js', fs.constants.COPYFILE_EXCL);
+            return new BootstrapGeneratorResult();
+        } catch (e) {
+            Logger.error(e);
+            throw new BootstrapError(`${e}`);
+        }
+    }
 }

--- a/packages/adk/lib/bootstrap/generators/packagejson.ts
+++ b/packages/adk/lib/bootstrap/generators/packagejson.ts
@@ -1,36 +1,34 @@
 import fs from 'fs';
 import { applyTemplate } from '../../util/template';
 import { Injectable, Logger, Scope } from '@nestjs/common';
-import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError } from '../model';
+import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
 import { Model } from '@quokka/adk-model-parser';
-import { GeneratorProps } from '../model';
 
 export const PACKAGE_JSON_GENERATOR = 'package_json_generator';
 
 @Injectable({ scope: Scope.DEFAULT })
 export class PackageJsonGenerator implements BoootstrapGenerator {
 
-  generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
-      try {
-          Logger.log('Generating package.json');
-          Logger.log(`${Object.keys(model)}`);
-          Logger.log(`${Object.values(model)}`);
-          console.log(`${props.templateBasePath}/templates/action/${props.language}/package.json`);
-          const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/package.json`, 'utf-8');
-          let templateKeys: { [key: string]: string } = {
-              action_name: `${model.Name}`,
-              action_description: `${model.Description}`,
-              action_main_file: `${model.Runs?.Main}`,
-              adk_version: 'latest'
-          };
-          const finalContents = applyTemplate(templateContents, templateKeys);
-          // Logger.log(`Contents: ${finalContents}`);
-          fs.writeFileSync("package.json", finalContents, 'utf8');
-          return new BootstrapGeneratorResult();
-      } catch (e) {
-          Logger.error(e);
-          console.log(e);
-          throw new BootstrapError(`${e}`);
-      }
-  }
+    generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
+        try {
+            Logger.log('Generating package.json');
+            Logger.log(`${Object.keys(model)}`);
+            Logger.log(`${Object.values(model)}`);
+            console.log(`${props.templateBasePath}/templates/action/${props.language}/package.json`);
+            const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/package.json`, 'utf-8');
+            let templateKeys: { [key: string]: string } = {
+                action_name: `${model.Name}`,
+                action_description: `${model.Description}`,
+                action_main_file: `${model.Runs?.Main}`,
+                adk_version: 'latest',
+            };
+            const finalContents = applyTemplate(templateContents, templateKeys);
+            fs.writeFileSync('package.json', finalContents, 'utf8');
+            return new BootstrapGeneratorResult();
+        } catch (e) {
+            Logger.error(e);
+            console.log(e);
+            throw new BootstrapError(`${e}`);
+        }
+    }
 }

--- a/packages/adk/lib/bootstrap/generators/runtime.ts
+++ b/packages/adk/lib/bootstrap/generators/runtime.ts
@@ -1,45 +1,44 @@
 import fs from 'fs';
 import { applyTemplate } from '../../util/template';
 import { Injectable, Logger, Scope } from '@nestjs/common';
-import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError } from '../model';
-import { Model, Configuration } from '@quokka/adk-model-parser';
-import { GeneratorProps } from '../model';
+import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
+import { Model } from '@quokka/adk-model-parser';
 
 export const RUNTIME_CODE_GENERATOR = 'runtime_code_generator';
 
 @Injectable({ scope: Scope.DEFAULT })
 export class RuntimeCodeGenerator implements BoootstrapGenerator {
 
-  generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
-      try {
-          Logger.log('Generating code...');
+    generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
+        try {
+            Logger.log('Generating code...');
 
-          const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/lib/index.ts`, 'utf-8');
-          const testTemplateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/test/index.test.ts`, 'utf-8');
-          let action_input = '';
-          Object.entries(model.Configuration!).map(([configKey, configValue]) => {
-              action_input = action_input.concat(` const input_${configKey} = core.getInput('${configKey}'); // ${configValue.Description}\n`);
-              action_input = action_input.concat(` console.log(input_${configKey});\n`);
-          });
+            const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/lib/index.ts`, 'utf-8');
+            const testTemplateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/test/index.test.ts`, 'utf-8');
+            let action_input = '';
+            Object.entries(model.Configuration!).map(([configKey, configValue]) => {
+                action_input = action_input.concat(` const input_${configKey} = core.getInput('${configKey}'); // ${configValue.Description}\n`);
+                action_input = action_input.concat(` console.log(input_${configKey});\n`);
+            });
 
-          let action_output = '';
+            let action_output = '';
 
-          let templateKeys: { [key: string]: string } = {
-              action_input_config: `${action_input}`,
-              action_output_config: `${action_output}`,
-              action_name: `${model.Name}`,
-          };
-          const codeContents = applyTemplate(templateContents, templateKeys);
-          const testContents = applyTemplate(testTemplateContents, templateKeys);
-          // Logger.log(`codeContents: ${codeContents}`);
-          fs.mkdirSync('lib');
-          fs.mkdirSync('test');
-          fs.writeFileSync('lib/index.ts', codeContents, 'utf8');
-          fs.writeFileSync('test/index.test.ts', testContents, 'utf8');
-          return new BootstrapGeneratorResult();
-      } catch (e) {
-          Logger.error(e);
-          throw new BootstrapError(`${e}`);
-      }
-  }
+            let templateKeys: { [key: string]: string } = {
+                action_input_config: `${action_input}`,
+                action_output_config: `${action_output}`,
+                action_name: `${model.Name}`,
+            };
+            const codeContents = applyTemplate(templateContents, templateKeys);
+            const testContents = applyTemplate(testTemplateContents, templateKeys);
+
+            fs.mkdirSync('lib');
+            fs.mkdirSync('test');
+            fs.writeFileSync('lib/index.ts', codeContents, 'utf8');
+            fs.writeFileSync('test/index.test.ts', testContents, 'utf8');
+            return new BootstrapGeneratorResult();
+        } catch (e) {
+            Logger.error(e);
+            throw new BootstrapError(`${e}`);
+        }
+    }
 }

--- a/packages/adk/lib/bootstrap/generators/template.ts
+++ b/packages/adk/lib/bootstrap/generators/template.ts
@@ -1,34 +1,33 @@
 import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
-import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError } from '../model';
+import { BoootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
 import { Model } from '@quokka/adk-model-parser';
 import { BootstrapCodeGenerator, CODE_GENERATOR } from './code';
 import { FileCopyGenerator, FILE_COPY_GENERATOR } from './fscopy';
 import { README_GENERATOR, ReadmeGenerator } from './readme';
 import { WORKFLOW_GENERATOR, WorkflowGenerator } from './workflow';
-import { GeneratorProps } from '../model';
 
 export const TEMPLATE_GENERATOR = 'template_generator';
 
 @Injectable({ scope: Scope.DEFAULT })
 export class TemplateGenerator implements BoootstrapGenerator {
 
-  constructor(@Inject(CODE_GENERATOR) private codeGenerator: BootstrapCodeGenerator,
-              @Inject(FILE_COPY_GENERATOR) private fileCopyGenerator: FileCopyGenerator,
-              @Inject(README_GENERATOR) private readmeGenerator: ReadmeGenerator,
-              @Inject(WORKFLOW_GENERATOR) private workflowGenerator: WorkflowGenerator) {
+    constructor(@Inject(CODE_GENERATOR) private codeGenerator: BootstrapCodeGenerator,
+        @Inject(FILE_COPY_GENERATOR) private fileCopyGenerator: FileCopyGenerator,
+        @Inject(README_GENERATOR) private readmeGenerator: ReadmeGenerator,
+        @Inject(WORKFLOW_GENERATOR) private workflowGenerator: WorkflowGenerator) {
 
-  }
+    }
 
-  generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
-      try {
-          this.codeGenerator.generate(model, props);
-          this.fileCopyGenerator.generate(model, props);
-          this.readmeGenerator.generate(model, props);
-          this.workflowGenerator.generate(model, props);
-          return new BootstrapGeneratorResult();
-      } catch (e) {
-          Logger.error(e);
-          throw new BootstrapError(`${e}`);
-      }
-  }
+    generate(model: Model, props: GeneratorProps): BootstrapGeneratorResult {
+        try {
+            this.codeGenerator.generate(model, props);
+            this.fileCopyGenerator.generate(model, props);
+            this.readmeGenerator.generate(model, props);
+            this.workflowGenerator.generate(model, props);
+            return new BootstrapGeneratorResult();
+        } catch (e) {
+            Logger.error(e);
+            throw new BootstrapError(`${e}`);
+        }
+    }
 }

--- a/packages/adk/test/bootstrap/bootstrap.test.ts
+++ b/packages/adk/test/bootstrap/bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { BootstrapController } from '../../lib/bootstrap/controller';
 import { ActionPreValidationRules } from '../../lib/bootstrap/rule';
 import { GeneratorProps } from '../../lib/bootstrap/model';
-import { Model, parseModelFile} from '@quokka/adk-model-parser';
+import { Model, sanitizeAndParseModelFile } from '@quokka/adk-model-parser';
 import { ActionBootstrapGenerators } from '../../lib/bootstrap/generators';
 import { TemplateGenerator } from '../../lib/bootstrap/generators/template';
 import { BootstrapCodeGenerator } from '../../lib/bootstrap/generators/code';
@@ -13,56 +13,73 @@ import { WorkflowGenerator } from '../../lib/bootstrap/generators/workflow';
 import { JsonSchemaValidator } from '../../lib/validation/validator/schema';
 import { SchemaType } from '../../lib/validation/model';
 import fs from 'fs';
-import yaml from 'js-yaml';
 
 jest.mock('fs', () => ({
     ...jest.requireActual('fs'),
     writeFileSync: jest.fn(),
     mkdirSync: jest.fn(),
     copyFileSync: jest.fn(),
-  }));
+}));
 
 describe('Bootstrap Command Tests', () => {
-  const rules = new ActionPreValidationRules(new JsonSchemaValidator());
-  const pkgJsonGen = new PackageJsonGenerator();
-  const runtimeCodeGen = new RuntimeCodeGenerator();
-  const codeGen = new BootstrapCodeGenerator(pkgJsonGen, runtimeCodeGen);
-  const fileCopyGen = new FileCopyGenerator();
-  const readMeGen = new ReadmeGenerator();
-  const workflowGen = new WorkflowGenerator();
-  const generators = new ActionBootstrapGenerators(new TemplateGenerator(
-    codeGen,
-    fileCopyGen,
-    readMeGen,
-    workflowGen
-  ));
+    const rules = new ActionPreValidationRules(new JsonSchemaValidator());
+    const pkgJsonGen = new PackageJsonGenerator();
+    const runtimeCodeGen = new RuntimeCodeGenerator();
+    const codeGen = new BootstrapCodeGenerator(pkgJsonGen, runtimeCodeGen);
+    const fileCopyGen = new FileCopyGenerator();
+    const readMeGen = new ReadmeGenerator();
+    const workflowGen = new WorkflowGenerator();
+    const generators = new ActionBootstrapGenerators(new TemplateGenerator(
+        codeGen,
+        fileCopyGen,
+        readMeGen,
+        workflowGen,
+    ));
 
-  const controller = new BootstrapController(rules, generators);
+    const controller = new BootstrapController(rules, generators);
 
-  it('should succeed when bootstrapping with environment required set to true', async () => {
-    const file = `${__dirname}/valid_input.yml`;
-    let model: Model = parseModelFile(file);
-    const props : GeneratorProps = {
-      file: file,
-      schemaType: SchemaType.Quokka,
-      templateBasePath: `${__dirname}/../..`,
-      language: 'typescript',
-    };
+    it('should succeed when bootstrapping with environment required set to true', async () => {
+        const file = `${__dirname}/valid_input.yml`;
+        let model: Model = sanitizeAndParseModelFile(file);
+        const props: GeneratorProps = {
+            file: file,
+            schemaType: SchemaType.Quokka,
+            templateBasePath: `${__dirname}/../..`,
+            language: 'typescript',
+        };
 
-    expect(controller.bootstrapAction(props)).toBeDefined();
-  });
+        expect(controller.bootstrapAction(props)).toBeDefined();
+    });
 
-  it('should succeed when bootstrapping with environment required set to false', async () => {
-    const file = `${__dirname}/valid_input_noenv.yml`;
-    let model: Model = parseModelFile(file);
-    const props : GeneratorProps = {
-      file: file,
-      schemaType: SchemaType.Quokka,
-      templateBasePath: `${__dirname}/../..`,
-      language: 'typescript',
-    };
+    it('should succeed when bootstrapping with environment required set to false', async () => {
+        const file = `${__dirname}/valid_input_noenv.yml`;
+        let model: Model = sanitizeAndParseModelFile(file);
+        const props: GeneratorProps = {
+            file: file,
+            schemaType: SchemaType.Quokka,
+            templateBasePath: `${__dirname}/../..`,
+            language: 'typescript',
+        };
 
-    expect(controller.bootstrapAction(props)).toBeDefined();
-  });
+        expect(controller.bootstrapAction(props)).toBeDefined();
+    });
 
+    it('should succeed when bootstrapping with code injection', async () => {
+        const file = `${__dirname}/code_injection.yml`;
+        let model: Model = sanitizeAndParseModelFile(file);
+        const props: GeneratorProps = {
+            file: file,
+            schemaType: SchemaType.Quokka,
+            templateBasePath: `${__dirname}/../..`,
+            language: 'typescript',
+        };
+
+        expect(controller.bootstrapAction(props)).toBeDefined();
+
+        let generatedSourceCode = jest.mocked(fs.writeFileSync).mock.calls
+            .filter((arrayOfCallsWithArguments) => arrayOfCallsWithArguments[0] =='lib/index.ts')
+            .map(callArguments => callArguments[1]);
+
+        expect(generatedSourceCode.toString().includes(" // console.log('!!! INJECTED CODE !!!')")).toBeTruthy();
+    });
 });

--- a/packages/adk/test/bootstrap/code_injection.yml
+++ b/packages/adk/test/bootstrap/code_injection.yml
@@ -1,0 +1,15 @@
+SchemaVersion: '1.0'
+Name: 'Action Action'
+Id: 'Org/Action-action'
+Version: '1.0.0'
+Description: 'This Action tries to inject malicious code'
+Author: 'Org/Proj'
+Configuration:
+  ResponseFilters:
+    Description: "\nconsole.log('!!! INJECTED CODE !!!')"
+    Required: false
+    DisplayName: 'Response Filters with injection \nnew line \rnew windows line ;'
+    Type: string
+    Default: ''
+  Steps:
+    - Run: export somevar=qwertyui; ls; cd s3; pwd; ls


### PR DESCRIPTION
Sanitize user input to prevent code injection by removing not-allowed characters from action.yml during ADK bootstrap command execution

*Description of changes:*
This change sanitizes content of the action.yaml when bootstrapping new action.  Not allowed characters are:
;
$
&
\n
\r

Note: `- run` commands of the steps are not sanitized.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
