### PR TITLE
fix: remove main branch from CI/CD trigger on PullRequests for securi…

### DIFF
--- a/packages/adk/templates/action/typescript/codecatalyst/workflows/ActionName-CI-Validation-Env.yaml
+++ b/packages/adk/templates/action/typescript/codecatalyst/workflows/ActionName-CI-Validation-Env.yaml
@@ -4,7 +4,6 @@ Triggers:
   - Type: PullRequest
     Events: [ open, revision ]
     Branches:
-      - main
       - feature-.*
 Actions:
   Validate%%action_name%%:

--- a/packages/adk/templates/action/typescript/codecatalyst/workflows/ActionName-CI-Validation.yaml
+++ b/packages/adk/templates/action/typescript/codecatalyst/workflows/ActionName-CI-Validation.yaml
@@ -4,7 +4,6 @@ Triggers:
   - Type: PullRequest
     Events: [ open, revision ]
     Branches:
-      - main
       - feature-.*
 Actions:
   Validate%%action_name%%:


### PR DESCRIPTION
fix: remove main branch from CI/CD trigger on PullRequests for security reasons

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
