### PR TITLE
fix: use 'process.env[input]' instead of 'printenv' to get env variable value

### DIFF
--- a/packages/adk-core/lib/toolkit/sdk/core/command-wrapper.ts
+++ b/packages/adk-core/lib/toolkit/sdk/core/command-wrapper.ts
@@ -15,15 +15,15 @@ export function runCommand(cmd: string, args?: string[]) {
 }
 
 export function getInputParam(inputVar: string) {
-    return runCommand('printenv', [inputVar]).stdout;
+    return process.env[inputVar] === undefined ? '' : process.env[inputVar];
 }
 
 export function setOutputParam(varName: string, varValue: string) {
     return runCommand(`echo "::set-output name=${varName}::${varValue}"`).stdout;
 }
 
-export function validateInput(inputVar: string) {
-    return inputVar.replace(/\n/g, '');
+export function validateInput(inputVar?: string) {
+    return inputVar?.replace(/\n/g, '');
 }
 
 export function setFailure(message: any, exitCode: number) {

--- a/packages/adk-core/lib/toolkit/sdk/core/core.ts
+++ b/packages/adk-core/lib/toolkit/sdk/core/core.ts
@@ -85,13 +85,13 @@ export interface ICommandOutput {
 */
 export class Utils {
     /** View documentation at {@link getInput | `getInput`} */
-    static getInput(inputVar: string) {
-        return validateInput(getEnvironmentVariable('INPUT_' + inputVar.toUpperCase()));
+    static getInput(inputVar?: string) {
+        return validateInput(getEnvironmentVariable('INPUT_' + inputVar?.toUpperCase()));
     }
 
     /** View documentation at {@link getMultiLineInput | `getMultiLineInput`} */
-    static getMultiLineInput(inputVar: string) {
-        return getEnvironmentVariable('INPUT_' + inputVar.toUpperCase());
+    static getMultiLineInput(inputVar?: string) {
+        return getEnvironmentVariable('INPUT_' + inputVar?.toUpperCase());
     }
 
     /** View documentation at {@link getEnvironmentVariable | `getEnvironmentVariable`} */

--- a/packages/adk-core/test/core.test.ts
+++ b/packages/adk-core/test/core.test.ts
@@ -38,4 +38,12 @@ describe('@codecatalyst/adk-core', () => {
         expect(adkCore.Utils.getMultiLineInput(varName)).toMatch(multiLineInputValue);
     });
 
+    it('should not fail with undefined input', () => {
+        let inputValue = undefined;
+        let varName = 'var1';
+        process.env.INPUT_VAR1 = inputValue;
+        expect(adkCore.getInput(varName)).toMatch('');
+        expect(adkCore.Utils.getInput(varName)).toMatch('');
+    });
+
 });


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
