### PR TITLE
set publish access to be 'public' to allow releasing adk package to npmjs

### DIFF
--- a/packages/adk-core/package.json
+++ b/packages/adk-core/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "author": {
-    "name": "AEF-Team",
-    "email": "cawsactionextensions@amazon.com",
+    "name": "Amazon CodeCatalyst",
+    "email": "https://codecatalyst.aws/",
     "organization": true
   },
   "repository": {

--- a/packages/adk-model-parser/package.json
+++ b/packages/adk-model-parser/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "author": {
-    "name": "AEF-Team",
-    "email": "cawsactionextensions@amazon.com",
+    "name": "Amazon CodeCatalyst",
+    "email": "https://codecatalyst.aws/",
     "organization": true
   },
   "scripts": {

--- a/packages/adk-utils/package.json
+++ b/packages/adk-utils/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "author": {
-    "name": "AEF-Team",
-    "email": "cawsactionextensions@amazon.com",
+    "name": "Amazon CodeCatalyst",
+    "email": "https://codecatalyst.aws/",
     "organization": true
   },
   "scripts": {

--- a/packages/adk/package.json
+++ b/packages/adk/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "author": {
-    "name": "AEF-Team",
-    "email": "cawsactionextensions@amazon.com",
+    "name": "Amazon CodeCatalyst",
+    "email": "https://codecatalyst.aws/",
     "organization": true
   },
   "bin": {

--- a/packages/codecatalyst-entities/project/package.json
+++ b/packages/codecatalyst-entities/project/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "author": {
-    "name": "AEF-Team",
-    "email": "cawsactionextensions@amazon.com",
+    "name": "Amazon CodeCatalyst",
+    "email": "https://codecatalyst.aws/",
     "organization": true
   },
   "files": [

--- a/packages/codecatalyst-entities/run-summaries/package.json
+++ b/packages/codecatalyst-entities/run-summaries/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "author": {
-    "name": "AEF-Team",
-    "email": "cawsactionextensions@amazon.com",
+    "name": "Amazon CodeCatalyst",
+    "email": "https://codecatalyst.aws/",
     "organization": true
   },
   "files": [

--- a/packages/codecatalyst-entities/space/package.json
+++ b/packages/codecatalyst-entities/space/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "author": {
-    "name": "AEF-Team",
-    "email": "cawsactionextensions@amazon.com",
+    "name": "Amazon CodeCatalyst",
+    "email": "https://codecatalyst.aws/",
     "organization": true
   },
   "files": [


### PR DESCRIPTION
## Description

set publish access to be 'public' to allow releasing adk package to npmjs

## Testing

npm run all

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
