### PR TITLE
fix: add a flag to enable or disable std input for the core.command() API

### DIFF
--- a/packages/adk-core/lib/toolkit/sdk/core/command-wrapper.ts
+++ b/packages/adk-core/lib/toolkit/sdk/core/command-wrapper.ts
@@ -4,9 +4,16 @@ import os from 'os';
 import { ICommandOutput } from './core';
 import { sanitizeCommand } from '@aws/codecatalyst-adk-utils/lib';
 
-export function runCommand(cmd: string, sanitizeInput: boolean = true, args?: string[]) {
+export function runCommand(cmd: string,
+    sanitizeInput: boolean = true,
+    disableStdInput: boolean = true,
+    args?: string[]) {
+
     const command_output = <ICommandOutput>{};
-    const sanitizedCommand = disableStdInput(sanitizeCommand(cmd, sanitizeInput, args));
+    const sanitizedCommand = disableStdInput
+        ? redirectStdInputToDevNull(sanitizeCommand(cmd, sanitizeInput, args))
+        : sanitizeCommand(cmd, sanitizeInput, args);
+
     const shell_command = exec(sanitizedCommand, { async: false });
     command_output.code = shell_command.code;
     command_output.stdout = shell_command.stdout;
@@ -32,6 +39,6 @@ export function setFailure(message: any, exitCode: number) {
     process.stdout.write(errorText + os.EOL);
 }
 
-function disableStdInput(cmd: string) {
+function redirectStdInputToDevNull(cmd: string) {
     return cmd + ' < /dev/null';
 }

--- a/packages/adk-core/lib/toolkit/sdk/core/core.ts
+++ b/packages/adk-core/lib/toolkit/sdk/core/core.ts
@@ -55,10 +55,14 @@ export function setOutput(varName: string, varValue: string) {
 * @param cmd The command to execute.
 * @param args The command arguments.
 * @param sanitizeInput If true, all the input is sanitized.
+* @param disableStdInput If true, standard input will be disabled for the command.
 * @return {@link ICommandOutput | `Command Output`}: The complex object with runtime execution parameters.
 */
-export function command(cmd: string, sanitizeInput: boolean = true, args?: string[]) {
-    return runCommand(cmd, sanitizeInput, args);
+export function command(cmd: string,
+    sanitizeInput: boolean = true,
+    disableStdInput: boolean = true,
+    args?: string[]) {
+    return runCommand(cmd, sanitizeInput, disableStdInput, args);
 }
 
 /**
@@ -107,8 +111,8 @@ export class Utils {
     }
 
     /** View documentation at {@link command | `command`} */
-    static command(cmd: string, sanitizeInput: boolean = true, args?: string[]) {
-        return runCommand(cmd, sanitizeInput, args);
+    static command(cmd: string, sanitizeInput: boolean = true, disableStdInput: boolean = true, args?: string[]) {
+        return runCommand(cmd, sanitizeInput, disableStdInput, args);
     }
 
 }

--- a/packages/adk-core/test/core.test.ts
+++ b/packages/adk-core/test/core.test.ts
@@ -64,6 +64,11 @@ describe('@aws/codecatalyst-adk-core', () => {
     });
 
     it('test command without stdin', () => {
+        const output = adkCore.command('ls', true, false);
+        expect(output.code === 0).toBeTruthy();
+    });
+
+    it('test command without stdin', () => {
         const output = adkCore.command('ls');
         expect(output.code === 0).toBeTruthy();
     });


### PR DESCRIPTION
## Description

fix the bug with the ADK core.command() API that was breaking commands with the pipe | character  

## Testing

unit testing

## Checklist

I have:
* [x] Added new automated tests for any new functionality
* [x] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
