### PR TITLE
ci: fix deploy docs workflow

### DIFF
--- a/.github/workflows/actions-dev-kit-deploy-docs.yml
+++ b/.github/workflows/actions-dev-kit-deploy-docs.yml
@@ -40,6 +40,7 @@ jobs:
       # Checkout main branch
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.base_ref }}
           # Checkout with ssh key to be able to push changes back to the branch
           ssh-key: ${{ env.SSH_PRIVATE_KEY }}
       # Install dependencies
@@ -52,5 +53,6 @@ jobs:
       - run: yarn run all #build
       - run: yarn run api-ref #generate /docs
       # Commit /docs folder back to the main branch. GitHub then deploys it automatically to GitHub pages
-      - run: git status && git add -f docs && git commit --amend --no-edit && git push
-
+      - run: git status && git add . && git add -f docs
+      - run: git commit -m "chore(docs) - update API reference"
+      - run: git push


### PR DESCRIPTION
## Description

fixes committing generated API reference docs from the ./docs folder back to the main branch

## Testing

tested in the gamma branch 

## Checklist

I have:
* [x] Added new automated tests for any new functionality
* [x] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
