### PR TITLE
ci: minor refactor of release-gamma and deploy-docs workflows

### DIFF
--- a/.github/workflows/actions-dev-kit-deploy-docs.yml
+++ b/.github/workflows/actions-dev-kit-deploy-docs.yml
@@ -54,5 +54,5 @@ jobs:
       - run: yarn run api-ref #generate /docs
       # Commit /docs folder back to the main branch. GitHub then deploys it automatically to GitHub pages
       - run: git status && git add . && git add -f docs
-      - run: git commit -m "chore(docs) - update API reference"
+      - run: 'git commit -m "chore(docs): - update API reference"'
       - run: git push

--- a/.github/workflows/actions-dev-kit-release-gamma.yml
+++ b/.github/workflows/actions-dev-kit-release-gamma.yml
@@ -2,7 +2,6 @@
 # It must be executed on the gamma branch where the real definition is.
 
 name: adk-release-to-gamma
-
 on: [workflow_dispatch]
 
 env:
@@ -13,3 +12,7 @@ jobs:
   release-to-gamma:
     runs-on: ubuntu-latest
     permissions: write-all
+
+    steps:
+      - name: Log warning
+        run: 'echo "Gamma release workflow. Must be run on the gamma branch."'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "adk",
   "private": true,
   "devDependencies": {
     "@tsconfig/node12": "^1.0.2",


### PR DESCRIPTION
ci: minor refactor of release-gamma and deploy-docs workflows
docs: rename API reference root to adk

## Description

Make cosmetic changes in the mentioned workflows
Rename API reference root to be adk - https://aws.github.io/actions-dev-kit/ 

## Testing

tested locally with https://github.com/nektos/act

## Checklist

I have:
* [ ] Added new automated tests for any new functionality
* [ ] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
