### PR TITLE
Use current ADK version in action's dependencies  

### DIFF
--- a/packages/adk/lib/bootstrap/generators/packagejson.ts
+++ b/packages/adk/lib/bootstrap/generators/packagejson.ts
@@ -5,6 +5,9 @@ import { BootstrapGenerator, BootstrapGeneratorResult, BootstrapError, Generator
 import { Model } from '@aws/codecatalyst-adk-model-parser';
 import { writeContentToFileSync } from '@aws/codecatalyst-adk-utils/lib';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pj = require('../../../package.json');
+
 export const PACKAGE_JSON_GENERATOR = 'package_json_generator';
 export const PACKAGE_JSON_GENERATOR_DESTINATION_FILES = ['package.json'];
 
@@ -19,7 +22,7 @@ export class PackageJsonGenerator implements BootstrapGenerator {
                 action_name: `${model.Name}`,
                 action_description: `${model.Description}`,
                 action_main_file: `${model.Runs?.Main}`,
-                adk_version: 'latest',
+                adk_version: `^${pj.version}`,
             };
             const finalContents = applyTemplate(templateContents, templateKeys);
             writeContentToFileSync('package.json', finalContents, props.overrideFiles);

--- a/packages/adk/package.json
+++ b/packages/adk/package.json
@@ -35,7 +35,9 @@
     "jsonschema": "^1.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "^7.8.0",
-    "yargs": "^17.7.1"
+    "yargs": "^17.7.1",
+    "@aws/codecatalyst-adk-utils": "1.0.13",
+    "@aws/codecatalyst-adk-model-parser": "1.0.13"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",


### PR DESCRIPTION
## Description

fix: 
 - use current ADK version in action's dependencies  
 - fix ADK CLI missing dependencies issue

## Testing

Tested with the gamma version of ADK

## Checklist

I have:
* [ ] Added new automated tests for any new functionality
* [x] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
