### PR TITLE
fix: make readme template more generic

### DIFF
--- a/packages/adk/lib/adk.ts
+++ b/packages/adk/lib/adk.ts
@@ -1,5 +1,5 @@
 import { handleCommand as init } from './commands/init';
-import { product_name } from './util/product';
+import { productName } from './util/product';
 import { version as adk_version } from './util/version';
 import { ProductInfo } from './types/types';
 import chalk from 'chalk';
@@ -48,22 +48,22 @@ async function cliArgs() {
         })
         .command('init', 'Initializes the current workspace with default Action definition', (yargs) => {
             return yargs
-                .option(product_name() + '-space', {
+                .option(productName() + '-space', {
                     type: 'string',
                     alias: 'space',
-                    desc: product_name() + ' Space to work against',
+                    desc: productName() + ' Space to work against',
                     requiresArg: true,
                 })
-                .option(product_name() + '-project', {
+                .option(productName() + '-project', {
                     type: 'string',
                     alias: 'proj',
-                    desc: product_name() + ' Project to work against',
+                    desc: productName() + ' Project to work against',
                     requiresArg: true,
                 })
-                .option(product_name() + '-repository', {
+                .option(productName() + '-repository', {
                     type: 'string',
                     alias: 'repo',
-                    desc: product_name() + ' source repository to work against',
+                    desc: productName() + ' source repository to work against',
                     requiresArg: true,
                 })
                 .option('action', {
@@ -81,7 +81,7 @@ async function cliArgs() {
                 .option('disconnected', {
                     type: 'boolean',
                     default: false,
-                    desc: 'If true, only generates ADK project files locally, without syncing with ' + product_name(),
+                    desc: 'If true, only generates ADK project files locally, without syncing with ' + productName(),
                 });
         })
         .version(adk_version())

--- a/packages/adk/lib/bootstrap/generators/license.ts
+++ b/packages/adk/lib/bootstrap/generators/license.ts
@@ -4,10 +4,11 @@ import { Injectable, Logger, Scope } from '@nestjs/common';
 import { BootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
 import { Model } from '@aws/codecatalyst-adk-model-parser';
 import { writeContentToFileSync } from '@aws/codecatalyst-adk-utils/lib';
+import { read_space } from '../../util/space';
 
 
 export const LICENSE_GENERATOR = 'license_generator';
-export const ACTION_CONFIG_FILE = '.actionconfig';
+
 export const LICENSE_GENERATOR_DESTINATION_FILES = ['LICENSE'];
 
 @Injectable({ scope: Scope.DEFAULT })
@@ -17,20 +18,8 @@ export class LicenseGenerator implements BootstrapGenerator {
         try {
             Logger.log('Generating MIT LICENSE');
             const year = new Date().getFullYear();
-            let copyRightHolder = '';
-
             const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/LICENSE.md`, 'utf-8');
-            if (fs.existsSync(ACTION_CONFIG_FILE)) {
-                const actionConfig = fs.readFileSync(ACTION_CONFIG_FILE, 'utf-8');
-                if (actionConfig) {
-                    actionConfig.split(/\r?\n/).forEach(function (line) {
-                        const space = line.split('codecatalyst_space: ')[1];
-                        if (space) {
-                            copyRightHolder = space;
-                        }
-                    });
-                }
-            }
+            const copyRightHolder = read_space();
 
             let templateKeys: { [key: string]: string } = {
                 YEAR: `${year}`,

--- a/packages/adk/lib/bootstrap/generators/license.ts
+++ b/packages/adk/lib/bootstrap/generators/license.ts
@@ -4,7 +4,7 @@ import { Injectable, Logger, Scope } from '@nestjs/common';
 import { BootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
 import { Model } from '@aws/codecatalyst-adk-model-parser';
 import { writeContentToFileSync } from '@aws/codecatalyst-adk-utils/lib';
-import { read_space } from '../../util/space';
+import { readSpace } from '../../util/space';
 
 
 export const LICENSE_GENERATOR = 'license_generator';
@@ -19,7 +19,7 @@ export class LicenseGenerator implements BootstrapGenerator {
             Logger.log('Generating MIT LICENSE');
             const year = new Date().getFullYear();
             const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/LICENSE.md`, 'utf-8');
-            const copyRightHolder = read_space();
+            const copyRightHolder = readSpace();
 
             let templateKeys: { [key: string]: string } = {
                 YEAR: `${year}`,

--- a/packages/adk/lib/bootstrap/generators/readme.ts
+++ b/packages/adk/lib/bootstrap/generators/readme.ts
@@ -16,17 +16,11 @@ export class ReadmeGenerator implements BootstrapGenerator {
             Logger.log('Generating README');
 
             const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/README.md`, 'utf-8');
-            let action_use = `
-            MyAction:
-              Configuration:`;
-
-            Object.entries(model.Configuration!).map(([configKey, configValue]) => {
-                action_use = action_use.concat(`
-                    ${configKey} : 'test' # ${configValue.Description}`);
-            });
+            let action_name = model.Name?.split(' ', 1);
 
             let templateKeys: { [key: string]: string } = {
-                action_usage: `${action_use}`,
+                ACTION_NAME: `${action_name}`,
+                ACTION_NAME_LOWERCASE: `${action_name}`.toLowerCase(),
             };
             const finalContents = applyTemplate(templateContents, templateKeys);
             writeContentToFileSync('README.md', finalContents, props.overrideFiles);

--- a/packages/adk/lib/bootstrap/generators/readme.ts
+++ b/packages/adk/lib/bootstrap/generators/readme.ts
@@ -4,7 +4,7 @@ import { Injectable, Logger, Scope } from '@nestjs/common';
 import { BootstrapGenerator, BootstrapGeneratorResult, BootstrapError, GeneratorProps } from '../model';
 import { Model } from '@aws/codecatalyst-adk-model-parser';
 import { writeContentToFileSync } from '@aws/codecatalyst-adk-utils/lib';
-import { read_space } from '../../util/space';
+import { readSpace } from '../../util/space';
 
 export const README_GENERATOR = 'readme_generator';
 export const README_GENERATOR_DESTINATION_FILES = ['README.md'];
@@ -18,7 +18,7 @@ export class ReadmeGenerator implements BootstrapGenerator {
 
             const templateContents = fs.readFileSync(`${props.templateBasePath}/templates/action/${props.language}/README.md`, 'utf-8');
             let action_name = model.Name?.split(' ', 1);
-            let space_name = read_space();
+            let space_name = readSpace();
             if (!fs.existsSync('../')) {
                 fs.mkdirSync('.codecatalyst/workflows', { recursive: true });
             }

--- a/packages/adk/lib/util/product.ts
+++ b/packages/adk/lib/util/product.ts
@@ -1,5 +1,5 @@
 const PRODUCT_NAME = 'codecatalyst';
 
-export function product_name() {
+export function productName() {
     return PRODUCT_NAME;
 }

--- a/packages/adk/lib/util/space.ts
+++ b/packages/adk/lib/util/space.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 export const ACTION_CONFIG_FILE = '.actionconfig';
 
-export function read_space(): string {
-    let result = '';
+export function readSpace(): string {
+    let result = '<space-name>';
     if (fs.existsSync(ACTION_CONFIG_FILE)) {
         const actionConfig = fs.readFileSync(ACTION_CONFIG_FILE, 'utf-8');
         if (actionConfig) {

--- a/packages/adk/lib/util/space.ts
+++ b/packages/adk/lib/util/space.ts
@@ -1,0 +1,19 @@
+import fs from 'fs';
+export const ACTION_CONFIG_FILE = '.actionconfig';
+
+export function read_space(): string {
+    let result = '';
+    if (fs.existsSync(ACTION_CONFIG_FILE)) {
+        const actionConfig = fs.readFileSync(ACTION_CONFIG_FILE, 'utf-8');
+        if (actionConfig) {
+            actionConfig.split(/\r?\n/).forEach(function (line) {
+                const space = line.split('codecatalyst_space: ')[1];
+                if (space) {
+                    result = space;
+                }
+            });
+        }
+    }
+
+    return result;
+}

--- a/packages/adk/templates/action/typescript/README.md
+++ b/packages/adk/templates/action/typescript/README.md
@@ -1,4 +1,4 @@
-# About the "ACTIONNAME" action
+# About the "%%ACTION_NAME%%" action
 <!--
 - Explain why your customers would use this action. 
 - What does it offer? 
@@ -7,7 +7,7 @@
 - Example content follows.
 --->
 
-The **ACTIONNAME** action synthesizes and deploys your [AWS Cloud Development Kit (AWS CDK)](https://aws.amazon.com/cdk/) app into AWS. If your app already exists in AWS, the action updates it if necessary.
+The **%%ACTION_NAME%%** action greets a person by name with a hello message.
 
 
 ## Basic example
@@ -17,160 +17,64 @@ The **ACTIONNAME** action synthesizes and deploys your [AWS Cloud Development Ki
 - If the action relies on other actions, include the larger workflow YAML.  
 - Example content follows. -->
 
-The following example shows the **ACTIONNAME** action deploying an AWS CDK stack called `my-app-stack` into the `us-west-2` AWS Region. The AWS CDK source files are in a repository represented by the label, `WorkflowSource`.
+The following example shows how to configure **%%ACTION_NAME%%-CI-workflow**.
 
 > **Note**:  The example is for illustrative purposes, and will not work without additional configuration.
 
 
 ```
-Name: codecatalyst-cdk-deploy-workflow
+Name: %%ACTION_NAME%%-CI-workflow
 SchemaVersion: 1.0
 ...
 Actions:      
-  ACTIONNAME:
-    Identifier: aws/cdk-deploy@v1
-    Environment:
-      Name: codecatalyst-cdk-deploy-environment
-      Connections:
-        - Name: codecatalyst-account-connection
-          Role: codecatalyst-cdk-deploy-role
+  %%ACTION_NAME%%:
+    Identifier: %%ACTION_NAME_LOWERCASE%%@v1
     Inputs:
       Sources:
         - WorkflowSource
     Configuration:
-      StackName: my-app-stack
-      Region: us-west-2
+      WhoToGreet: Name
+      HowToGreet: Hello there,
 ```
 ---
 
 Configuration properties used in this example are described below.
 
-> **Note**: For a full list of properties along with detailed descriptions, see [Additional resources](#additional-resources).
 
-### ACTIONNAME
+### %%ACTION_NAME%%
 
-The friendly name for the **ACTIONNAME** action, and is used as a label in logs when the action runs.
-
-Required: Yes
-
-Default: CDKDeploy_nn
-
----
-
-### ACTIONNAME.Identifier
-
-Identifies the action. Do not change this property.
+The friendly name for the **%%ACTION_NAME%%** action, and is used as a label in logs when the action runs.
 
 Required: Yes
 
-Default: aws/cdk-deploy@v1 (do not change)
+Default: %%ACTION_NAME%%
 
 ---
 
-### ACTIONNAME.Environment.Name
+### Identifier
 
-The name of an existing environment that you want to associate with the action.  For information about environments, see [Working with environments](https://docs.aws.amazon.com/codecatalyst/latest/userguide/deploy-environments.html) in the *Amazon CodeCatalyst User Guide*.
+Identifies the action. 
 
 Required: Yes
 
-Default: none
+Default: %%ACTION_NAME_LOWERCASE%%@v1
 
 ---
 
-### ACTIONNAME.Environment.Connections.Name
-
-The name of the account connection.  For information about account connections, see [Adding an AWS account to a space](https://docs.aws.amazon.com/codecatalyst/latest/userguide/ipa-connect-account-create.html) in the *Amazon CodeCatalyst User Guide*.
-
-Required: Yes
-
-Default: none
-
----
-
-### ACTIONNAME.Environment.Connections.Role
-
-The name of the IAM role that the **AWS CDK deploy** action uses to access AWS and deploy the AWS CDK application stack. Make sure that this role includes:
-
-The following permissions policy:
-
-> **Warning**: Limit the permissions to those shown in the following policy. Using a role with broader permissions might pose a security risk.
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "VisualEditor0",
-            "Effect": "Allow",
-            "Action": [
-                "cloudformation:DescribeStackEvents",
-                "cloudformation:DescribeChangeSet",
-                "cloudformation:DescribeStacks",
-                "cloudformation:ListStackResources"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Sid": "VisualEditor1",
-            "Effect": "Allow",
-            "Action": "sts:AssumeRole",
-            "Resource": "arn:aws:iam::aws-account:role/cdk-*"
-        }
-    ]
-}
-```
-The following custom trust policy:
-```
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Sid": "",
-                "Effect": "Allow",
-                "Principal": {
-                    "Service":  [
-                       "codecatalyst-runner.amazonaws.com",
-                       "codecatalyst.amazonaws.com"
-                     ]
-                },
-                "Action": "sts:AssumeRole"
-            }
-        ]
-    }
-```
-Make sure that this role is added to your account connection.
-
-For more information on creating IAM roles, see [Creating a role using a custom trust policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-custom.html) in the *AWS Identity and Access Management User Guide*.
-
-Required: Yes
-
-Default: none
-
----
-
-### ACTIONNAME.Inputs.Sources
+### Inputs.Sources
 
 
-If your AWS CDK app is stored in a source repository, specify the label of that source repository. Currently, the only supported label is `WorkflowSource`.
+If the action needs access to files stored in a source repository, specify the label of that source repository. Currently, the only supported label is `WorkflowSource`.
 
-Required: Yes, if the AWS CDK app you want to deploy is stored in a source repository.
+Required: Yes, if the action needs access to files stored in a source repository.
 
 Default: WorkFlowSource
 
 ---
 
-### ACTIONNAME.Configuration.StackName
+### Configuration.WhoToGreet
 
-The name of your AWS CDK app stack, as it appears in the entrypoint file in your AWS CDK app's bin directory.
-
-Required: Yes
-
-Default: none
-
----
-
-### ACTIONNAME.Configuration.Region
-
-The AWS Region into which the AWS CDK application stack will be deployed.
+Name of the person, who we are greeting here.
 
 Required: Yes
 
@@ -178,14 +82,23 @@ Default: none
 
 ---
 
-## How the "ACTIONNAME" action works
+### Configuration.HowToGreet
+
+How to greet the person.
+
+Required: No
+
+Default: "Hello there,"
+
+---
+
+## How the "%%ACTION_NAME%%" action works
 <!-- An optional section where you can describe behind-the-scenes processing, or extra details. 
 Example content follows. -->
 
-The **ACTIONNAME** action works as follows:
+The **%%ACTION_NAME%%** action works as follows:
 
-- At runtime, the action installs the AWS CDK Toolkit to the CodeCatalyst build image. The toolkit is necessary to run the `cdk deploy` command, next.
-- The action runs the `cdk deploy` command, which synthesizes and deploys your AWS CDK app into AWS. For more information on this command, see the [AWS CDK Toolkit (cdk command)](https://docs.aws.amazon.com/cdk/v2/guide/cli.html) topic in the *AWS Cloud Development Kit (AWS CDK) Developer Guide*.
+- At runtime, the action logs a greeting line composed of a configured name and message.
 
 ## Troubleshooting
 <!-- An optional section where you can provide a link to troubleshooting information. 
@@ -195,8 +108,8 @@ For troubleshooting information, see [Troubleshooting problems with workflows](h
 ## Additional resources
 <!-- Add links to other places in your docs, as required. -->
 
-- [ACTIONNAME definition reference](https://www.mycompany.com/docs/ACTIONNAME-action-yaml) - Describes all **ACTIONNAME** action properties in detail.
+- [%%ACTION_NAME%% definition reference](https://www.mycompany.com/docs/ACTIONNAME-action-yaml) - Describes all **%%ACTION_NAME%%** action properties in detail.
 - [Workflow definition reference](https://www.mycompany.com/docs/ACTIONNAME-workflow-yaml) - Describes all available workflow definition file properties in detail.
-- [Tutorial](https://www.mycompany.com/docs/ACTIONNAME-action-tut) - Step-by-step instructions on getting the **ACTIONNAME** action running in an example scenario.
+- [Tutorial](https://www.mycompany.com/docs/ACTIONNAME-action-tut) - Step-by-step instructions on getting the **%%ACTION_NAME%%** action running in an example scenario.
 - [Provide feedback](www.mycompany.com/feedback) - Submit a ticket against this action.
 

--- a/packages/adk/templates/action/typescript/README.md
+++ b/packages/adk/templates/action/typescript/README.md
@@ -28,7 +28,7 @@ SchemaVersion: 1.0
 ...
 Actions:      
   %%ACTION_NAME%%:
-    Identifier: %%ACTION_NAME_LOWERCASE%%@v1
+    Identifier: %%CODECATALYST_SPACE_LOWERCASE%%/%%ACTION_NAME_LOWERCASE%%@v1
     Environment:
       Name: codecatalyst-environment
       Connections:
@@ -37,9 +37,7 @@ Actions:
     Inputs:
       Sources:
         - WorkflowSource
-    Configuration:
-      WhoToGreet: Name
-      HowToGreet: Hello there,
+%%ACTION_USAGE%%
 ```
 ---
 
@@ -55,6 +53,17 @@ Required: Yes
 Default: %%ACTION_NAME%%
 
 ---
+
+### Identifier
+
+Identifies the action.
+
+Required: Yes
+
+Default: %%CODECATALYST_SPACE_LOWERCASE%%/%%ACTION_NAME_LOWERCASE%%@v1
+
+---
+
 ### Environment.Name
 
 The name of an existing environment that you want to associate with the action.  For information about environments, see [Working with environments](https://docs.aws.amazon.com/codecatalyst/latest/userguide/deploy-environments.html) in the *Amazon CodeCatalyst User Guide*.
@@ -132,16 +141,6 @@ The following custom trust policy:
 Make sure that this role is added to your account connection.
 
 For more information on creating IAM roles, see [Creating a role using a custom trust policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-custom.html) in the *AWS Identity and Access Management User Guide*.
-
----
-
-### Identifier
-
-Identifies the action. 
-
-Required: Yes
-
-Default: %%ACTION_NAME_LOWERCASE%%@v1
 
 ---
 

--- a/packages/adk/templates/action/typescript/README.md
+++ b/packages/adk/templates/action/typescript/README.md
@@ -29,6 +29,11 @@ SchemaVersion: 1.0
 Actions:      
   %%ACTION_NAME%%:
     Identifier: %%ACTION_NAME_LOWERCASE%%@v1
+    Environment:
+      Name: codecatalyst-environment
+      Connections:
+        - Name: codecatalyst-account-connection
+          Role: codecatalyst-role
     Inputs:
       Sources:
         - WorkflowSource
@@ -48,6 +53,85 @@ The friendly name for the **%%ACTION_NAME%%** action, and is used as a label in 
 Required: Yes
 
 Default: %%ACTION_NAME%%
+
+---
+### Environment.Name
+
+The name of an existing environment that you want to associate with the action.  For information about environments, see [Working with environments](https://docs.aws.amazon.com/codecatalyst/latest/userguide/deploy-environments.html) in the *Amazon CodeCatalyst User Guide*.
+
+Required: No
+
+Default: none
+
+---
+
+### Environment.Connections.Name
+
+The name of the account connection. For information about account connections, see [Adding an AWS account to a space](https://docs.aws.amazon.com/codecatalyst/latest/userguide/ipa-connect-account-create.html) in the *Amazon CodeCatalyst User Guide*.
+
+Required: Yes
+
+Default: none
+
+---
+
+### Environment.Connections.Role
+
+The name of the IAM role that the **%%ACTION_NAME%%** action uses to access AWS resources. Make sure that the role includes:
+
+
+The following permissions policy:
+
+> **Warning**: Limit the permissions to the minimum required for the action to run successfully. Using a role with broader permissions might pose a security risk.
+
+> **Note**:  The example is for illustrative purposes, and will not work without additional configuration.
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "cloudformation:DescribeStackEvents",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:DescribeStacks",
+                "cloudformation:ListStackResources"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "arn:aws:iam::aws-account:role/cdk-*"
+        }
+    ]
+}
+```
+The following custom trust policy:
+```
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Principal": {
+                    "Service":  [
+                       "codecatalyst-runner.amazonaws.com",
+                       "codecatalyst.amazonaws.com"
+                     ]
+                },
+                "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+```
+Make sure that this role is added to your account connection.
+
+For more information on creating IAM roles, see [Creating a role using a custom trust policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-custom.html) in the *AWS Identity and Access Management User Guide*.
 
 ---
 

--- a/packages/adk/test/util/util.test.ts
+++ b/packages/adk/test/util/util.test.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import chalk from 'chalk';
-import { product_name } from '../../lib/util/product';
+import { productName } from '../../lib/util/product';
 import { ConsoleLogger } from '../../lib/util/logger';
 
 const mockChalk: jest.Mocked<typeof chalk> = <jest.Mocked<typeof chalk>>chalk;
@@ -17,7 +17,7 @@ describe('@aws/codecatalyst-adk-utils', () => {
     const log = new ConsoleLogger();
 
     it('test product', () => {
-        expect('codecatalyst' === product_name()).toBeTruthy();
+        expect('codecatalyst' === productName()).toBeTruthy();
     });
 
     it('test chalk', () => {


### PR DESCRIPTION
## Description

fix: make readme template more generic

## Testing

tested generating new readme locally

## Checklist

I have:
* [ ] Added new automated tests for any new functionality
* [ x] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
