### PR TITLE
Revert "fix: update output variable validation (#264)" and "docs: upd…

### DIFF
--- a/packages/adk-core/lib/toolkit/sdk/core/core.ts
+++ b/packages/adk-core/lib/toolkit/sdk/core/core.ts
@@ -38,7 +38,7 @@ export function getEnvironmentVariable(inputVar: string) {
 /**
 * Sets the output value for the action output parameter.
 *
-* @param varName The name of the environment variable. The variable must match the ^[A-Za-z0-9@\\-_]+$ pattern.
+* @param varName The name of the environment variable. The variable must match the ^[A-Za-z0-9][A-Za-z0-9\-_]{1,30}[A-Za-z0-9]$ pattern.
 * @param varValue The fully resolved value of the output variable.
 *
 * @return The result of running `echo ${varName}`.

--- a/packages/adk-core/test/core.test.ts
+++ b/packages/adk-core/test/core.test.ts
@@ -81,7 +81,7 @@ describe('@aws/codecatalyst-adk-core', () => {
 
         const emptyInput = '';
         const invalidInput = 'Stack ID';
-        const tooLongInput = 'longer_than_255_chars_123456789101112131415161718487612357845768929562892576458234765287495628495682412345678910111213141516171848761235784576892956289257645823476528749562849568241234567891011121314151617184876123578457689295628925764582347652874956284959';
+        const tooLongInput = 'longer_than_30_chars_123456789101112131415161718';
         const startsWithInvalidChar = '-Stack_ID';
         const endsWithInvalidChar = 'Stack_ID-';
 

--- a/packages/adk-utils/lib/util/util.ts
+++ b/packages/adk-utils/lib/util/util.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-export const outputVariableNamePattern = new RegExp(/^[A-Za-z0-9@\\-_]+$/);
+export const outputVariableNamePattern = new RegExp(/^[A-Za-z0-9][A-Za-z0-9\-_]{1,30}[A-Za-z0-9]$/);
 
 /**
  * Sanitizes (escapes) special characters in the command and its arguments.
@@ -91,8 +91,5 @@ export function writeContentToFileSync(dest: string, content: string, overrideDe
  * @param varName The destination file.
  */
 export function isValidOutputVariableName(varName: string): boolean {
-    if (!varName || varName.length < 1 || varName.length > 255) {
-        return false;
-    }
     return outputVariableNamePattern.test(varName);
 }

--- a/packages/adk-utils/test/util.test.ts
+++ b/packages/adk-utils/test/util.test.ts
@@ -132,7 +132,7 @@ describe('ADK-Util test', () => {
         const validInput30Chars = 'Stack_ID_12345678910111213145';
         const emptyInput = '';
         const invalidInput = 'Stack ID';
-        const tooLongInput = 'longer_than_255_chars_123456789101112131415161718487612357845768929562892576458234765287495628495682412345678910111213141516171848761235784576892956289257645823476528749562849568241234567891011121314151617184876123578457689295628925764582347652874956284959';
+        const tooLongInput = 'longer_than_30_chars_123456789101112131415161718';
         const startsWithInvalidChar = '-Stack_ID';
         const endsWithInvalidChar = 'Stack_ID-';
 


### PR DESCRIPTION
…ate API ref for the setOutput API (#265)"

This reverts commits 4bc87f71ff940ef9f80f3dec981273dd1403f6ae and 31dc4fd001c0d0f6752ceaa90e0f777a6b4f2a8c.

## Description

This change reverts commits relating to changes in output variable validation.

## Testing

./build.sh
yarn run test-all

## Checklist

I have:
* [ ] Added new automated tests for any new functionality
* [x] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
