### PR TITLE
Update disableStdInput for command with pipe

### DIFF
--- a/packages/adk-core/lib/toolkit/sdk/core/core.ts
+++ b/packages/adk-core/lib/toolkit/sdk/core/core.ts
@@ -61,7 +61,7 @@ export function command(cmd: string,
     sanitizeInput: boolean = true,
     disableStdInput: boolean = true,
     args?: string[]) {
-    return runCommand(cmd, sanitizeInput, disableStdInput, args);
+    return runCommand(cmd, sanitizeInput, disableStdInput && !cmd.includes(' | '), args);
 }
 
 /**

--- a/packages/adk-core/test/core.test.ts
+++ b/packages/adk-core/test/core.test.ts
@@ -59,6 +59,21 @@ describe('@aws/codecatalyst-adk-core', () => {
         expect(process.exitCode === 1).toBeTruthy();
     });
 
+    it('test command with pipe', () => {
+        const output = adkCore.command('echo "Hello" | grep "lo"');
+        expect(output.code === 0).toBeTruthy();
+    });
+
+    it('test command with pipe', () => {
+        const output = adkCore.command('echo "Hello" | grep "po"');
+        expect(output.code === 0).toBeTruthy();
+    });
+
+    it('test command with and', () => {
+        const output = adkCore.command('echo "Hello" && echo "World"');
+        expect(output.code === 0).toBeTruthy();
+    });
+
     it('test command with stdin', () => {
         const output = adkCore.command('read test');
         expect(output.code === 1).toBeTruthy();

--- a/packages/adk-core/test/core.test.ts
+++ b/packages/adk-core/test/core.test.ts
@@ -64,11 +64,6 @@ describe('@aws/codecatalyst-adk-core', () => {
         expect(output.code === 0).toBeTruthy();
     });
 
-    it('test command with pipe', () => {
-        const output = adkCore.command('echo "Hello" | grep "po"');
-        expect(output.code === 0).toBeTruthy();
-    });
-
     it('test command with and', () => {
         const output = adkCore.command('echo "Hello" && echo "World"');
         expect(output.code === 0).toBeTruthy();


### PR DESCRIPTION
## Description

_A brief description of the changes made_

Before this change, action using ADK is not able to process commands with pipe(|), it keeps failing with 

```
Action Failed, reason: Error
::set-output name=ACTION_RUN_SUMMARY::[{text:CUSTOM,message:"Error",level:Error}]
Action Failed, reason: Error
```

The reason of this weird behavior is we have a `disableStdInput` for `runCommand()` in adk core, when this setting is true, it stops standard input for the command. This causes trouble with pipe commands because we usually want to use the output of the first command as input for the second. And by default, disableStdInput is true, leading to issues.

To fix this, the change mainly involves setting `disableStdInput` as false when we have (|) in the command, so that shelljs won't fail when the second command is executed.

Also added additional test cases for pipe commands.


## Testing

_Steps taken to verify the changes_

`npm run build`

`npm run test`

Used `npm link` and tested in CoCa workflow.

Example workflow: https://integ.stage.quokka.codes/spaces/Build/projects/test-on-aef/workflows/72e1cae3-e35b-4d96-ac4d-8332c8cfff3d/runs/4b026e51-b3c3-47e5-ad83-0831fa9ca365/view?activeTabId=visual


## Checklist

I have:
* [👍] Added new automated tests for any new functionality
* [👍] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
