### PR TITLE
bump gamma version to 1.0.21 & use node 18.x

### DIFF
--- a/.github/workflows/actions-dev-kit-release-gamma.yml
+++ b/.github/workflows/actions-dev-kit-release-gamma.yml
@@ -20,7 +20,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.x
           registry-url: ${{ secrets.CODEARTIFACT_NPM_REGISTRY_GAMMA }}
           scope: '@aws'
       # Install dependencies

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,7 @@
     "packages/*",
     "packages/codecatalyst-entities/*"
   ],
-  "version": "1.0.20",
+  "version": "1.0.21",
   "command": {
     "version": {
       "allowBranch": "gamma",


### PR DESCRIPTION
## Description
 Testing to have node 18 in gamma release wf

I have:
* [ ] Added new automated tests for any new functionality
* [ ] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
