### PR TITLE
Connection field to be a sub-field of Environment in ADK template

### DIFF
--- a/packages/adk/templates/codecatalyst_model_schema.json
+++ b/packages/adk/templates/codecatalyst_model_schema.json
@@ -169,6 +169,19 @@
         "Required": {
           "description": "A boolean to indicate whether the action requires Environment Connection Set to true when the parameter is required.",
           "type": "boolean"
+        },
+        "Connection": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "Required": {
+              "description": "A boolean to indicate whether the action requires AWS Account Connection. Set to true when the parameter is required.",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "Required"
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
Update ADK template with Connection field to be a sub-field of Environment

## Description

Update ADK template with Connection field to be a sub-field of Environment
## Testing
- build and test against MyAction with Connection Field
```
MyActionRepo$ adk validate
Starting action validation
Validation Passed
Command exit code 0
```

## Checklist


I have:
- [ ] Added new automated tests for any new functionality
- [ ] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
